### PR TITLE
config: split 4xx and 5xx threshold parameters

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'NginxHighHttp4xxErrorRate',
             expr: |||
-              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^4.*", ingress!~"%(ignoredIngresses)s"}[%(interval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(interval)s]))  by (exported_namespace, ingress) * 100) > %(threshold)s
+              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^4.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress) * 100) > %(ingressNginx4xxThreshold)s
             ||| % $._config,
             'for': '30s',
             labels: {
@@ -15,18 +15,18 @@
             },
             annotations: {
               summary: 'Nginx high HTTP 4xx error rate.',
-              description: 'More than %(threshold)s%% HTTP requests with status 4xx for {{ $labels.ingress }}/{{ $labels.exported_namespace }} the past %(interval)s.' % $._config,
+              description: 'More than %(ingressNginx4xxThreshold)s%% HTTP requests with status 4xx for {{ $labels.ingress }}/{{ $labels.exported_namespace }} the past %(ingressNginx4xxInterval)s.' % $._config,
               dashboard_url: '%(grafanaUrl)s/d/%(overviewDashboardUid)s/nginx-ingress-controller?orgId=1&refresh=5s' % $._config,
             },
           },
           {
             alert: 'NginxHighHttp5xxErrorRate',
             expr: |||
-              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^5.*", ingress!~"%(ignoredIngresses)s"}[%(interval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(interval)s]))  by (exported_namespace, ingress) * 100) > %(threshold)s
+              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^5.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress) * 100) > %(ingressNginx5xxThreshold)s
             ||| % $._config,
             annotations: {
               summary: 'Nginx high HTTP 5xx error rate.',
-              description: 'More than %(threshold)s%% HTTP requests with status 5xx for {{ $labels.ingress }}/{{ $labels.exported_namespace }} the past %(interval)s.' % $._config,
+              description: 'More than %(ingressNginx5xxThreshold)s%% HTTP requests with status 5xx for {{ $labels.ingress }}/{{ $labels.exported_namespace }} the past %(ingressNginx5xxInterval)s.' % $._config,
               dashboard_url: '%(grafanaUrl)s/d/%(overviewDashboardUid)s/nginx-ingress-controller?orgId=1&refresh=5s' % $._config,
             },
             'for': '30s',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -5,7 +5,9 @@
     grafanaUrl: 'https://grafana.com',
     overviewDashboardUid: '4x6xvSN7z',
     ignoredIngresses: '',
-    interval: '5m',
-    threshold: '5',  // percent
+    ingressNginx4xxInterval: '5m',
+    ingressNginx4xxThreshold: '5',  // percent
+    ingressNginx5xxInterval: '5m',
+    ingressNginx5xxThreshold: '5',  // percent
   },
 }


### PR DESCRIPTION
This allows people to set different thresholds for each class of error.

Also add a ingressNginx prefix.