### PR TITLE
Give user the ability to configure single/multi-cluster dashboards and alerts

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -9,7 +9,7 @@
             expr: |||
               sum(
                 nginx_ingress_controller_config_last_reload_successful{%(ingressNginxSelector)s}
-              ) by (job, controller_class)
+              ) by (job, controller_class, %(clusterLabel)s)
               == 0
             ||| % $._config,
             'for': '5m',
@@ -25,7 +25,7 @@
           {
             alert: 'NginxHighHttp4xxErrorRate',
             expr: |||
-              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^4.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress) * 100) > %(ingressNginx4xxThreshold)s
+              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^4.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress, %(clusterLabel)s) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx4xxInterval)s]))  by (exported_namespace, ingress, %(clusterLabel)s) * 100) > %(ingressNginx4xxThreshold)s
             ||| % $._config,
             'for': '1m',
             labels: {
@@ -40,7 +40,7 @@
           {
             alert: 'NginxHighHttp5xxErrorRate',
             expr: |||
-              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^5.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress) * 100) > %(ingressNginx5xxThreshold)s
+              (sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, status=~"^5.*", ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress, %(clusterLabel)s) / sum(rate(nginx_ingress_controller_requests{%(ingressNginxSelector)s, ingress!~"%(ignoredIngresses)s"}[%(ingressNginx5xxInterval)s]))  by (exported_namespace, ingress, %(clusterLabel)s) * 100) > %(ingressNginx5xxThreshold)s
             ||| % $._config,
             'for': '1m',
             annotations: {

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -1,4 +1,5 @@
 {
+  local clusterVariabletoAdd = if $._config.enableMultiCluster then '&%(clusterLabel)s={{ $labels.%(clusterLabel)s}}' % $._config else '',
   prometheusAlerts+:: {
     groups+: [
       {
@@ -19,7 +20,7 @@
             annotations: {
               summary: 'Nginx config reload failed.',
               description: 'Nginx config reload failed for the controller with the class {{ $labels.controller_class }}.',
-              dashboard_url: $._config.overviewDashboardUrl + '?var-job={{ $labels.job }}&var-controller_class={{ $labels.controller_class }}',
+              dashboard_url: $._config.overviewDashboardUrl + '?var-job={{ $labels.job }}&var-controller_class={{ $labels.controller_class }}' + clusterVariabletoAdd,
             },
           },
           {
@@ -34,7 +35,7 @@
             annotations: {
               summary: 'Nginx high HTTP 4xx error rate.',
               description: 'More than %(ingressNginx4xxThreshold)s%% HTTP requests with status 4xx for {{ $labels.exported_namespace }}/{{ $labels.ingress }} the past %(ingressNginx4xxInterval)s.' % $._config,
-              dashboard_url: $._config.overviewDashboardUrl + '?var-exported_namespace={{ $labels.exported_namespace }}&var-ingress={{ $labels.ingress }}',
+              dashboard_url: $._config.overviewDashboardUrl + '?var-exported_namespace={{ $labels.exported_namespace }}&var-ingress={{ $labels.ingress }}' + clusterVariabletoAdd,
             },
           },
           {
@@ -46,7 +47,7 @@
             annotations: {
               summary: 'Nginx high HTTP 5xx error rate.',
               description: 'More than %(ingressNginx5xxThreshold)s%% HTTP requests with status 5xx for {{ $labels.exported_namespace }}/{{ $labels.ingress }} the past %(ingressNginx5xxInterval)s.' % $._config,
-              dashboard_url: $._config.overviewDashboardUrl + '?var-exported_namespace={{ $labels.exported_namespace }}&var-ingress={{ $labels.ingress }}',
+              dashboard_url: $._config.overviewDashboardUrl + '?var-exported_namespace={{ $labels.exported_namespace }}&var-ingress={{ $labels.ingress }}' + clusterVariabletoAdd,
             },
             labels: {
               severity: $._config.ingressNginx5xxSeverity,

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -13,6 +13,7 @@ local annotation = g.dashboard.annotation;
     ingressNginxSelector: 'job=~"ingress-nginx-controller-metrics"',
     
     enableMultiCluster: false,
+    clusterLabel: if self.enableMultiCluster then 'cluster' else '',
     clusterCondition: if self.enableMultiCluster then 'cluster="$cluster"' else '',
 
     grafanaUrl: 'https://grafana.com',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -11,6 +11,9 @@ local annotation = g.dashboard.annotation;
 
     // Selectors are inserted between {} in Prometheus queries.
     ingressNginxSelector: 'job=~"ingress-nginx-controller-metrics"',
+    
+    enableMultiCluster: false,
+    clusterCondition: if self.enableMultiCluster then 'cluster="$cluster"' else '',
 
     grafanaUrl: 'https://grafana.com',
 


### PR DESCRIPTION
This PR gives user the ability to change b/w single and multicluster dashboards and alerts.
There is no need to insert the cluster label in summary and description because all the labels on the metric that triggers the alarm form part of the label group .